### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/code/src/Attendee/Attendee.cs
+++ b/code/src/Attendee/Attendee.cs
@@ -9,7 +9,12 @@ namespace Attendees
     {
         public void WriteToDirectory(ZipArchiveEntry entry, string destDirectory)
         {
-            string destFileName = Path.Combine(destDirectory, entry.FullName);
+            string destFileName = Path.GetFullPath(Path.Combine(destDirectory, entry.FullName));
+            string fullDestDirPath = Path.GetFullPath(destDirectory + Path.DirectorySeparatorChar);
+            if (!destFileName.StartsWith(fullDestDirPath, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("Entry is outside the target directory: " + destFileName);
+            }
             entry.ExtractToFile(destFileName);
         }
         


### PR DESCRIPTION
Potential fix for [https://github.com/ravsrini/skills-secure-repository-supply-chain/security/code-scanning/1](https://github.com/ravsrini/skills-secure-repository-supply-chain/security/code-scanning/1)

To fix the issue, we need to validate the file paths extracted from the zip archive to ensure they do not escape the intended destination directory. This involves:

1. Using `Path.Combine` to construct the raw output path.
2. Resolving the raw output path using `Path.GetFullPath` to handle any directory traversal elements.
3. Resolving the destination directory path using `Path.GetFullPath` and appending a directory separator to ensure proper comparison.
4. Validating that the resolved output path starts with the resolved destination directory path. If it does not, throw an exception to prevent writing outside the intended directory.
5. Proceeding with the extraction only if the validation passes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
